### PR TITLE
Enhance backfill flow

### DIFF
--- a/features/api/simple-flow/runForecast/editDataThenRunForecast.feature
+++ b/features/api/simple-flow/runForecast/editDataThenRunForecast.feature
@@ -504,6 +504,14 @@ Feature: APIs Advanced Edit Item History, PUT /api/history-override, Purchase As
         And The status text is "<expectedStatusText>"
         And User picks a random item which does not have Purchase As
         And User saves the item key
+        # Update doNotOrder = flase => show in Purchasing
+        And User sets PUT api endpoint to edit doNotOrder of the above item for company type <companyType> with new value: false
+        And User sends a PUT request to edit the item
+        And The expected status code should be <expectedStatus>
+        # Update forecastDirty = true => will run forecast
+        And User sets PUT api endpoint to edit forecastDirty of the above item for company type <companyType> with new value: true
+        And User sends a PUT request to edit the item
+        And The expected status code should be <expectedStatus>
         # Turn ON Override history
         And User sets PUT api endpoint to edit useHistoryOverride of the above item for company type <companyType> with new value: <value>
         And User sends a PUT request to edit the item
@@ -567,6 +575,14 @@ Feature: APIs Advanced Edit Item History, PUT /api/history-override, Purchase As
         And The status text is "<expectedStatusText>"
         And User picks a random item which does not have Purchase As
         And User saves the item key
+        # Update doNotOrder = flase => show in Purchasing
+        And User sets PUT api endpoint to edit doNotOrder of the above item for company type <companyType> with new value: false
+        And User sends a PUT request to edit the item
+        And The expected status code should be <expectedStatus>
+        # Update forecastDirty = true => will run forecast
+        And User sets PUT api endpoint to edit forecastDirty of the above item for company type <companyType> with new value: true
+        And User sends a PUT request to edit the item
+        And The expected status code should be <expectedStatus>
         # Turn ON Override history
         And User sets PUT api endpoint to edit useHistoryOverride of the above item for company type <companyType> with new value: <value>
         And User sends a PUT request to edit the item
@@ -634,6 +650,14 @@ Feature: APIs Advanced Edit Item History, PUT /api/history-override, Purchase As
         And The status text is "<expectedStatusText>"
         And User picks a random item which does not have Purchase As
         And User saves the item key
+        # Update doNotOrder = flase => show in Purchasing
+        And User sets PUT api endpoint to edit doNotOrder of the above item for company type <companyType> with new value: false
+        And User sends a PUT request to edit the item
+        And The expected status code should be <expectedStatus>
+        # Update forecastDirty = true => will run forecast
+        And User sets PUT api endpoint to edit forecastDirty of the above item for company type <companyType> with new value: true
+        And User sends a PUT request to edit the item
+        And The expected status code should be <expectedStatus>
         # Turn ON Override history
         And User sets PUT api endpoint to edit useHistoryOverride of the above item for company type <companyType> with new value: <value>
         And User sends a PUT request to edit the item
@@ -706,6 +730,18 @@ Feature: APIs Advanced Edit Item History, PUT /api/history-override, Purchase As
         And The status text is "<expectedStatusText>"
         And User picks a random item which does not have Purchase As
         And User saves the item key
+        # Update doNotOrder = flase => show in Purchasing
+        And User sets PUT api endpoint to edit doNotOrder of the above item for company type <companyType> with new value: false
+        And User sends a PUT request to edit the item
+        And The expected status code should be <expectedStatus>
+        # Update forecastDirty = true => will run forecast
+        And User sets PUT api endpoint to edit forecastDirty of the above item for company type <companyType> with new value: true
+        And User sends a PUT request to edit the item
+        And The expected status code should be <expectedStatus>
+        # Update forecastDirty = true => will run forecast
+        And User sets PUT api endpoint to edit forecastDirty of the above item for company type <companyType> with new value: true
+        And User sends a PUT request to edit the item
+        And The expected status code should be <expectedStatus>
         # Turn ON Override history
         And User sets PUT api endpoint to edit useHistoryOverride of the above item for company type <companyType> with new value: <value>
         And User sends a PUT request to edit the item
@@ -778,6 +814,14 @@ Feature: APIs Advanced Edit Item History, PUT /api/history-override, Purchase As
         And The status text is "<expectedStatusText>"
         And User picks a random item which does not have Purchase As
         And User saves the item key
+        # Update doNotOrder = flase => show in Purchasing
+        And User sets PUT api endpoint to edit doNotOrder of the above item for company type <companyType> with new value: false
+        And User sends a PUT request to edit the item
+        And The expected status code should be <expectedStatus>
+        # Update forecastDirty = true => will run forecast
+        And User sets PUT api endpoint to edit forecastDirty of the above item for company type <companyType> with new value: true
+        And User sends a PUT request to edit the item
+        And The expected status code should be <expectedStatus>
         # Turn ON Override history
         And User sets PUT api endpoint to edit useHistoryOverride of the above item for company type <companyType> with new value: <value>
         And User sends a PUT request to edit the item
@@ -835,7 +879,7 @@ Feature: APIs Advanced Edit Item History, PUT /api/history-override, Purchase As
             | TC_BFV005_2 | ASC         | testautoforecast@gmail.com | 20       | 200            | OK                 | useBackfill | true  |
             | TC_BFV005_3 | QBFS        | testautoforecast@gmail.com | 20       | 200            | OK                 | useBackfill | true  |
 
-    @TC_BFV006 @smoke-test-api @regression-api @api-backfill-value
+    @TC_BFV006 @smoke-test-api @regression-api @api-backfill-value 
     Scenario Outline: <TC_ID> - Verify that the system will fill "0" for orther months. if the 1st year, 2nd year has no value and the 3rd year has full values for <companyType>
         Given User picks company which has onboarded before with type <companyType> in above response
         And User sets valid cookie of <email> and valid companyKey and valid companyType in the header
@@ -845,6 +889,14 @@ Feature: APIs Advanced Edit Item History, PUT /api/history-override, Purchase As
         And The status text is "<expectedStatusText>"
         And User picks a random item which does not have Purchase As
         And User saves the item key
+        # Update doNotOrder = flase => show in Purchasing
+        And User sets PUT api endpoint to edit doNotOrder of the above item for company type <companyType> with new value: false
+        And User sends a PUT request to edit the item
+        And The expected status code should be <expectedStatus>
+        # Update forecastDirty = true => will run forecast
+        And User sets PUT api endpoint to edit forecastDirty of the above item for company type <companyType> with new value: true
+        And User sends a PUT request to edit the item
+        And The expected status code should be <expectedStatus>
         # Turn ON Override history
         And User sets PUT api endpoint to edit useHistoryOverride of the above item for company type <companyType> with new value: <value>
         And User sends a PUT request to edit the item

--- a/features/api/simple-flow/runForecast/editDataThenRunForecast.feature
+++ b/features/api/simple-flow/runForecast/editDataThenRunForecast.feature
@@ -504,11 +504,11 @@ Feature: APIs Advanced Edit Item History, PUT /api/history-override, Purchase As
         And The status text is "<expectedStatusText>"
         And User picks a random item which does not have Purchase As
         And User saves the item key
-        # Update doNotOrder = flase => show in Purchasing
+        # Update doNotOrder = flase => show in Purchasing to check historySnapshot
         And User sets PUT api endpoint to edit doNotOrder of the above item for company type <companyType> with new value: false
         And User sends a PUT request to edit the item
         And The expected status code should be <expectedStatus>
-        # Update forecastDirty = true => will run forecast
+        # This step was captured when user takes action on browser. Update forecastDirty = true => will run forecast
         And User sets PUT api endpoint to edit forecastDirty of the above item for company type <companyType> with new value: true
         And User sends a PUT request to edit the item
         And The expected status code should be <expectedStatus>
@@ -575,11 +575,11 @@ Feature: APIs Advanced Edit Item History, PUT /api/history-override, Purchase As
         And The status text is "<expectedStatusText>"
         And User picks a random item which does not have Purchase As
         And User saves the item key
-        # Update doNotOrder = flase => show in Purchasing
+        # Update doNotOrder = flase => show in Purchasing to check historySnapshot
         And User sets PUT api endpoint to edit doNotOrder of the above item for company type <companyType> with new value: false
         And User sends a PUT request to edit the item
         And The expected status code should be <expectedStatus>
-        # Update forecastDirty = true => will run forecast
+        # This step was captured when user takes action on browser. Update forecastDirty = true => will run forecast
         And User sets PUT api endpoint to edit forecastDirty of the above item for company type <companyType> with new value: true
         And User sends a PUT request to edit the item
         And The expected status code should be <expectedStatus>
@@ -650,11 +650,11 @@ Feature: APIs Advanced Edit Item History, PUT /api/history-override, Purchase As
         And The status text is "<expectedStatusText>"
         And User picks a random item which does not have Purchase As
         And User saves the item key
-        # Update doNotOrder = flase => show in Purchasing
+        # Update doNotOrder = flase => show in Purchasing to check historySnapshot
         And User sets PUT api endpoint to edit doNotOrder of the above item for company type <companyType> with new value: false
         And User sends a PUT request to edit the item
         And The expected status code should be <expectedStatus>
-        # Update forecastDirty = true => will run forecast
+        # This step was captured when user takes action on browser. Update forecastDirty = true => will run forecast
         And User sets PUT api endpoint to edit forecastDirty of the above item for company type <companyType> with new value: true
         And User sends a PUT request to edit the item
         And The expected status code should be <expectedStatus>
@@ -730,11 +730,11 @@ Feature: APIs Advanced Edit Item History, PUT /api/history-override, Purchase As
         And The status text is "<expectedStatusText>"
         And User picks a random item which does not have Purchase As
         And User saves the item key
-        # Update doNotOrder = flase => show in Purchasing
+        # Update doNotOrder = flase => show in Purchasing to check historySnapshot
         And User sets PUT api endpoint to edit doNotOrder of the above item for company type <companyType> with new value: false
         And User sends a PUT request to edit the item
         And The expected status code should be <expectedStatus>
-        # Update forecastDirty = true => will run forecast
+        # This step was captured when user takes action on browser. Update forecastDirty = true => will run forecast
         And User sets PUT api endpoint to edit forecastDirty of the above item for company type <companyType> with new value: true
         And User sends a PUT request to edit the item
         And The expected status code should be <expectedStatus>        
@@ -810,11 +810,11 @@ Feature: APIs Advanced Edit Item History, PUT /api/history-override, Purchase As
         And The status text is "<expectedStatusText>"
         And User picks a random item which does not have Purchase As
         And User saves the item key
-        # Update doNotOrder = flase => show in Purchasing
+        # Update doNotOrder = flase => show in Purchasing to check historySnapshot 
         And User sets PUT api endpoint to edit doNotOrder of the above item for company type <companyType> with new value: false
         And User sends a PUT request to edit the item
         And The expected status code should be <expectedStatus>
-        # Update forecastDirty = true => will run forecast
+        # This step was captured when user takes action on browser. Update forecastDirty = true => will run forecast
         And User sets PUT api endpoint to edit forecastDirty of the above item for company type <companyType> with new value: true
         And User sends a PUT request to edit the item
         And The expected status code should be <expectedStatus>
@@ -885,11 +885,11 @@ Feature: APIs Advanced Edit Item History, PUT /api/history-override, Purchase As
         And The status text is "<expectedStatusText>"
         And User picks a random item which does not have Purchase As
         And User saves the item key
-        # Update doNotOrder = flase => show in Purchasing
+        # Update doNotOrder = flase => show in Purchasing to check historySnapshot
         And User sets PUT api endpoint to edit doNotOrder of the above item for company type <companyType> with new value: false
         And User sends a PUT request to edit the item
         And The expected status code should be <expectedStatus>
-        # Update forecastDirty = true => will run forecast
+        # This step was captured when user takes action on browser. Update forecastDirty = true => will run forecast
         And User sets PUT api endpoint to edit forecastDirty of the above item for company type <companyType> with new value: true
         And User sends a PUT request to edit the item
         And The expected status code should be <expectedStatus>

--- a/features/api/simple-flow/runForecast/editDataThenRunForecast.feature
+++ b/features/api/simple-flow/runForecast/editDataThenRunForecast.feature
@@ -737,11 +737,7 @@ Feature: APIs Advanced Edit Item History, PUT /api/history-override, Purchase As
         # Update forecastDirty = true => will run forecast
         And User sets PUT api endpoint to edit forecastDirty of the above item for company type <companyType> with new value: true
         And User sends a PUT request to edit the item
-        And The expected status code should be <expectedStatus>
-        # Update forecastDirty = true => will run forecast
-        And User sets PUT api endpoint to edit forecastDirty of the above item for company type <companyType> with new value: true
-        And User sends a PUT request to edit the item
-        And The expected status code should be <expectedStatus>
+        And The expected status code should be <expectedStatus>        
         # Turn ON Override history
         And User sets PUT api endpoint to edit useHistoryOverride of the above item for company type <companyType> with new value: <value>
         And User sends a PUT request to edit the item

--- a/features/step_definitions/api/dashboard/item.steps.ts
+++ b/features/step_definitions/api/dashboard/item.steps.ts
@@ -912,6 +912,30 @@ Given('User sets PUT api endpoint to edit {} of the above item for company type 
 
             this.payLoad.useBackfill =  this.useBackfill
             break;
+        case 'doNotOrder':                      
+            if (value == 'random') {
+                this.doNotOrder = !(Boolean(this.responseBodyOfAItemObject.doNotOrder));
+            }
+            else {
+                this.doNotOrder = value;                
+            }
+            logger.log('info', `New ${editColumn}: ${this.doNotOrder}`);
+            this.attach(`New ${editColumn}: ${this.doNotOrder}`);
+    
+            this.payLoad.doNotOrder =  this.doNotOrder            
+            break;
+        case 'forecastDirty':                      
+            if (value == 'random') {
+                this.forecastDirty = !(Boolean(this.responseBodyOfAItemObject.forecastDirty));
+            }
+            else {
+                this.forecastDirty = value;                
+            }
+            logger.log('info', `New ${editColumn}: ${this.forecastDirty}`);
+            this.attach(`New ${editColumn}: ${this.forecastDirty}`);
+    
+            this.payLoad.forecastDirty =  this.forecastDirty            
+            break;
         default:
             break;
     }    


### PR DESCRIPTION
- Get item with doNotOrder=true => Don’t show in Purchasing.
Resolve: set doNotOrder = false before editing history override.

- Run forecast does not work when updating item history
Resolve: set forecastDirty = true after updating item history